### PR TITLE
Assembleur ne gère pas les données fournis via un label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 */__pycache__/
+*.pyc
+bin/

--- a/data/affiche12.txt
+++ b/data/affiche12.txt
@@ -1,0 +1,13 @@
+    load r2 r0 nb_iter
+    add r1 r0 0
+loop_for_start:
+    sle r4 r1 r2
+    braz r4 loop_for_end
+    add r20 r0 r1
+    scall 1
+    add r1 r1 1
+    jmp r0 loop_for_start
+loop_for_end:
+    stop
+nb_iter:
+    12

--- a/data/instruction_test.txt
+++ b/data/instruction_test.txt
@@ -44,10 +44,10 @@
 #add r1 r0 9
 #add r20 r1 r0
 #scall 1
-add r1 r0 3
-add r2 r0 2
-store r1 r2 8	    # mem[ra + offset] <= rs    (29) checked instruction. Error: Stored the register number and not its value. Resolved.
-load r2 r2 8      # checked instruction.
+#add r1 r0 3
+#add r2 r0 2
+#store r1 r2 8	    # mem[ra + offset] <= rs    (29) checked instruction. Error: Stored the register number and not its value. Resolved.
+#load r2 r2 8      # checked instruction.
 #
 # Branchements
 #jmp ra, rd		    # rd <= PC ; PC <= ra           (30)
@@ -79,4 +79,11 @@ load r2 r2 8      # checked instruction.
 #scall 4             # write string pointed to by r20(34) //to checked. Don't know how to correctly implement.
 #
 # Arrêt machine
-stop                # arrêt machine                 (35) checked instruction.
+#stop                # arrêt machine                 (35) checked instruction.
+
+#On teste l'utilisation de data numérique dans un code simple d'assembleur
+    load r20 r0 data
+    scall 1
+    stop    
+data:
+    5

--- a/src/assembleur.py
+++ b/src/assembleur.py
@@ -28,6 +28,11 @@ class Assembly():
             'opcode': 99,
             'format': 'r'
         },
+        "data": {
+            'regex': r"^\s*([0-9]*)\s*$",
+            'opcode': 99,
+            'format': 'data'
+        },
         'add': {
             'regex': r"^\s*(add)\s+r(\d+)\s+r(\d+)\s+r(\d+)",
             'opcode': 2,
@@ -192,11 +197,11 @@ class Assembly():
     address = 0
     labels = {}
     labels_used = {}
-    opcode=0
-    arg1=0
-    arg2=0
-    arg3=0
-    format='r'
+    opcode = 0
+    arg1 = 0
+    arg2 = 0
+    arg3 = 0
+    format = 'r'
 
     def __init__(self, source, destination) -> None:
         print("This is the Assembly class to assemble files for a mini-MIPS Virtual Machine.\n")
@@ -309,6 +314,8 @@ class Assembly():
                 return matching.group(3)
         if self.format in 's':
             self.arg1 = int(matching.group(2))
+        if self.format in 'data':
+            self.arg1 = int(matching.group(1))
 
     def write_binary_file(self, destination: str = "bin/destination.bin"):
         """
@@ -348,7 +355,8 @@ class Encode():
             'ji': self.encode_ji(),
             'b': self.encode_b(),
             's': self.encode_s(),
-            'h': self.encode_h()
+            'h': self.encode_h(),
+            'data':self.encode_data()
         }
         return switch[self.format]
 
@@ -423,6 +431,12 @@ class Encode():
         opcode = self.opcode << 26
         binary_instruction = opcode
         return binary_instruction
+
+    def encode_data(self):
+        """
+        Convert the recognized instruction into a binary instruction
+        """
+        return self.arg1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3

Résolu. Juste ajouté une reconnaissance des données numériques dans l'assembleur.
Attention quand on réalise un code assembleur à bien utiliser le load pour les data
Le principe du mini-MIPS est de faire des opérations entre registres.
Donc, attention à la programmation en assembleur pur. Peut engendrer des erreurs même si tout fonctionne.